### PR TITLE
Update ValidateRequestAttribute to use web.config

### DIFF
--- a/src/Twilio.AspNet.Mvc/Twilio.AspNet.Mvc.csproj
+++ b/src/Twilio.AspNet.Mvc/Twilio.AspNet.Mvc.csproj
@@ -22,6 +22,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.1\System.Configuration.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
@@ -46,5 +49,10 @@
     </PackageReference>
     <PackageReference Include="Twilio" Version="5.73.0" />
     <PackageReference Include="Twilio.AspNet.Common" Version="6.0.0-alpha" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Twilio.AspNet.Mvc.UnitTests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/Twilio.AspNet.Mvc/TwilioConfiguration.cs
+++ b/src/Twilio.AspNet.Mvc/TwilioConfiguration.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Configuration;
+
+namespace Twilio.AspNet.Mvc
+{
+    public class RequestValidationConfigurationSection : ConfigurationSection
+    {
+        [ConfigurationProperty("authToken")]
+        public string AuthToken
+        {
+            get => (string)this["authToken"];
+            set => this["authToken"] = value;
+        }
+
+        [ConfigurationProperty("urlOverride")]
+        public string UrlOverride
+        {
+            get => (string)this["urlOverride"];
+            set => this["urlOverride"] = value;
+        }
+
+        [ConfigurationProperty("allowLocal")]
+        public bool AllowLocal
+        {
+            get => (bool)this["allowLocal"];
+            set => this["allowLocal"] = value;
+        }
+    }
+
+    public class TwilioSectionGroup : ConfigurationSectionGroup
+    {
+
+        [ConfigurationProperty("requestValidation", IsRequired = false)]
+        public RequestValidationConfigurationSection RequestValidation
+        {
+            get { return (RequestValidationConfigurationSection)Sections["requestValidation"]; }
+        }
+    }
+}

--- a/src/testapps/AspNetFramework/Controllers/SmsController.cs
+++ b/src/testapps/AspNetFramework/Controllers/SmsController.cs
@@ -5,7 +5,7 @@ namespace AspNetFramework.Controllers
 {
     public class SmsController : TwilioController
     {
-        [ValidateRequest("your auth token here", urlOverride: "https://??????.ngrok.io/sms")]
+        [ValidateRequest]
         public TwiMLResult Index()
         {
             var messagingResponse = new MessagingResponse();

--- a/src/testapps/AspNetFramework/Web.config
+++ b/src/testapps/AspNetFramework/Web.config
@@ -4,11 +4,26 @@
   https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
+  <configSections>
+    <sectionGroup name="twilio" type="Twilio.AspNet.Mvc.TwilioSectionGroup,Twilio.AspNet.Mvc">
+	  <section name="requestValidation" type="Twilio.AspNet.Mvc.RequestValidationConfigurationSection,Twilio.AspNet.Mvc"/>
+	</sectionGroup>
+  </configSections>
+  <twilio>
+     <requestValidation 
+       authToken="your auth token here"
+       urlOverride="https://??????.ngrok.io/sms"
+       allowLocal="true"
+     />
+  </twilio>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+	<add key="twilio:requestValidation:authToken" value="your auth token here!"/>
+	<add key="twilio:requestValidation:urlOverride" value="https://??????.ngrok.io/sms"/>
+	<add key="twilio:requestValidation:allowLocal" value="true"/>
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.7.2" />


### PR DESCRIPTION
Instead of hardcoding the configuration into the `ValidateRequestAttribute`, you can now configure the attribute from the _Web.config_ file:

_Web.config_:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
<configSections>
  <sectionGroup name="twilio" type="Twilio.AspNet.Mvc.TwilioSectionGroup,Twilio.AspNet.Mvc">
    <section name="requestValidation" type="Twilio.AspNet.Mvc.RequestValidationConfigurationSection,Twilio.AspNet.Mvc"/>
  </sectionGroup>
</configSections>
<twilio>
   <requestValidation 
     authToken="your auth token here"
     urlOverride="https://??????.ngrok.io/sms"
     allowLocal="true"
   />
</twilio>
<appSettings>
  <add key="twilio:requestValidation:authToken" value="your auth token here!"/>
  <add key="twilio:requestValidation:urlOverride" value="https://??????.ngrok.io/sms"/>
  <add key="twilio:requestValidation:allowLocal" value="true"/>
</appSettings>
...
```

You can configure the attribute using the `twilio.requestValidation` section, but you can also override this configuration using the `appSettings`.
The reason for this is that `appSettings` has configuration builders which allow for storing the auth token as a secret.
Also on platforms like Azure Web Apps, you can override `appSettings` from the portal, but you cannot override the configuration sections.

Attribute usage is now like this:

```csharp
public class SmsController : TwilioController
{
  [ValidateRequest]
  public TwiMLResult Index(){}
}
```

`AuthToken`, `UrlOverride`, and `AllowLocal` cannot be configured through the constructor or object initializer.
However, you can still inherit from the attribute and configure the properties as you wish.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
