### PR TITLE
Replace UrlOverride with BaseUrlOverride

### DIFF
--- a/src/Twilio.AspNet.Core.UnitTests/ValidateRequestAttributeTests.cs
+++ b/src/Twilio.AspNet.Core.UnitTests/ValidateRequestAttributeTests.cs
@@ -17,7 +17,7 @@ public class ValidateRequestAttributeTests
         {
             AuthToken = "My Twilio:RequestValidation:AuthToken",
             AllowLocal = false,
-            UrlOverride = "MY URL OVERRIDE"
+            BaseUrlOverride = "MY URL OVERRIDE"
         }
     };
     
@@ -30,7 +30,7 @@ public class ValidateRequestAttributeTests
             var requestValidation = ValidTwilioOptions.RequestValidation;
             options.AuthToken = requestValidation.AuthToken;
             options.AllowLocal = requestValidation.AllowLocal;
-            options.UrlOverride = requestValidation.UrlOverride;
+            options.BaseUrlOverride = requestValidation.BaseUrlOverride;
         });
 
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -71,7 +71,7 @@ public class ValidateRequestAttributeTests
         {
             options.AllowLocal = ValidTwilioOptions.RequestValidation.AllowLocal;
             options.AuthToken = ValidTwilioOptions.RequestValidation.AuthToken;
-            options.UrlOverride = ValidTwilioOptions.RequestValidation.UrlOverride;
+            options.BaseUrlOverride = ValidTwilioOptions.RequestValidation.BaseUrlOverride;
         });
 
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -83,7 +83,7 @@ public class ValidateRequestAttributeTests
 
         Assert.Equal(ValidTwilioOptions.RequestValidation.AllowLocal, attribute.AllowLocal);
         Assert.Equal(ValidTwilioOptions.RequestValidation.AuthToken, attribute.AuthToken);
-        Assert.Equal(ValidTwilioOptions.RequestValidation.UrlOverride, attribute.UrlOverride);
+        Assert.Equal(ValidTwilioOptions.RequestValidation.BaseUrlOverride, attribute.BaseUrlOverride);
     }
     
     [Fact]

--- a/src/Twilio.AspNet.Core/RequestValidationDependencyInjectionExtensions.cs
+++ b/src/Twilio.AspNet.Core/RequestValidationDependencyInjectionExtensions.cs
@@ -41,7 +41,7 @@ namespace Twilio.AspNet.Core
         {
             // properties can be empty strings, but should be set to null if so
             if (options.AuthToken == "") options.AuthToken = null;
-            if (options.UrlOverride == "") options.UrlOverride = null;
+            if (options.BaseUrlOverride == "") options.BaseUrlOverride = null;
         }
     }
 }

--- a/src/Twilio.AspNet.Core/TwilioOptions.cs
+++ b/src/Twilio.AspNet.Core/TwilioOptions.cs
@@ -23,7 +23,7 @@ namespace Twilio.AspNet.Core
     {
         public string AuthToken { get; set; }
         public bool? AllowLocal { get; set; }
-        public string UrlOverride { get; set; }
+        public string BaseUrlOverride { get; set; }
     }
 
     public enum CredentialType

--- a/src/Twilio.AspNet.Mvc/Twilio.AspNet.Mvc.csproj
+++ b/src/Twilio.AspNet.Mvc/Twilio.AspNet.Mvc.csproj
@@ -56,7 +56,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.9" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Twilio.AspNet.Mvc/TwilioConfiguration.cs
+++ b/src/Twilio.AspNet.Mvc/TwilioConfiguration.cs
@@ -12,11 +12,11 @@ namespace Twilio.AspNet.Mvc
             set => this["authToken"] = value;
         }
 
-        [ConfigurationProperty("urlOverride")]
-        public string UrlOverride
+        [ConfigurationProperty("baseUrlOverride")]
+        public string BaseUrlOverride
         {
-            get => (string)this["urlOverride"];
-            set => this["urlOverride"] = value;
+            get => (string)this["baseUrlOverride"];
+            set => this["baseUrlOverride"] = value;
         }
 
         [ConfigurationProperty("allowLocal")]

--- a/src/Twilio.AspNet.Mvc/ValidateRequestAttribute.cs
+++ b/src/Twilio.AspNet.Mvc/ValidateRequestAttribute.cs
@@ -43,6 +43,7 @@ namespace Twilio.AspNet.Mvc
 
             BaseUrlOverride = appSettings["twilio:requestValidation:baseUrlOverride"]
                               ?? requestValidationConfiguration?.BaseUrlOverride;
+            if(BaseUrlOverride != null) BaseUrlOverride = BaseUrlOverride.TrimEnd('/');
 
             var allowLocalAppSetting = appSettings["twilio:requestValidation:allowLocal"];
             AllowLocal = allowLocalAppSetting != null

--- a/src/testapps/AspNetFramework/Web.config
+++ b/src/testapps/AspNetFramework/Web.config
@@ -4,67 +4,67 @@
   https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
-  <configSections>
-    <sectionGroup name="twilio" type="Twilio.AspNet.Mvc.TwilioSectionGroup,Twilio.AspNet.Mvc">
-	  <section name="requestValidation" type="Twilio.AspNet.Mvc.RequestValidationConfigurationSection,Twilio.AspNet.Mvc"/>
-	</sectionGroup>
-  </configSections>
-  <twilio>
-     <requestValidation 
-       authToken="your auth token here"
-       baseUrlOverride="https://??????.ngrok.io/sms"
-       allowLocal="true"
+	<configSections>
+		<sectionGroup name="twilio" type="Twilio.AspNet.Mvc.TwilioSectionGroup,Twilio.AspNet.Mvc">
+			<section name="requestValidation" type="Twilio.AspNet.Mvc.RequestValidationConfigurationSection,Twilio.AspNet.Mvc"/>
+		</sectionGroup>
+	</configSections>
+	<twilio>
+		<requestValidation
+		  authToken="your auth token here!"
+		  baseUrlOverride="https://??????.ngrok.io"
+		  allowLocal="true"
      />
-  </twilio>
-  <appSettings>
-    <add key="webpages:Version" value="3.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-	<add key="twilio:requestValidation:authToken" value="your auth token here!"/>
-	<add key="twilio:requestValidation:baseUrlOverride" value="https://??????.ngrok.io/sms"/>
-	<add key="twilio:requestValidation:allowLocal" value="true"/>
-  </appSettings>
-  <system.web>
-    <compilation debug="true" targetFramework="4.7.2" />
-    <httpRuntime targetFramework="4.7.2" />
-  </system.web>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
-  <system.codedom>
-    <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
-    </compilers>
-  </system.codedom>
+	</twilio>
+	<appSettings>
+		<add key="webpages:Version" value="3.0.0.0" />
+		<add key="webpages:Enabled" value="false" />
+		<add key="ClientValidationEnabled" value="true" />
+		<add key="UnobtrusiveJavaScriptEnabled" value="true" />
+		<add key="twilio:requestValidation:authToken" value="your auth token here!"/>
+		<add key="twilio:requestValidation:baseUrlOverride" value="https://??????.ngrok.io"/>
+		<add key="twilio:requestValidation:allowLocal" value="true"/>
+	</appSettings>
+	<system.web>
+		<compilation debug="true" targetFramework="4.7.2" />
+		<httpRuntime targetFramework="4.7.2" />
+	</system.web>
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" />
+				<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
+				<bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+	<system.codedom>
+		<compilers>
+			<compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+			<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+		</compilers>
+	</system.codedom>
 </configuration>

--- a/src/testapps/AspNetFramework/Web.config
+++ b/src/testapps/AspNetFramework/Web.config
@@ -12,7 +12,7 @@
   <twilio>
      <requestValidation 
        authToken="your auth token here"
-       urlOverride="https://??????.ngrok.io/sms"
+       baseUrlOverride="https://??????.ngrok.io/sms"
        allowLocal="true"
      />
   </twilio>
@@ -22,7 +22,7 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
 	<add key="twilio:requestValidation:authToken" value="your auth token here!"/>
-	<add key="twilio:requestValidation:urlOverride" value="https://??????.ngrok.io/sms"/>
+	<add key="twilio:requestValidation:baseUrlOverride" value="https://??????.ngrok.io/sms"/>
 	<add key="twilio:requestValidation:allowLocal" value="true"/>
   </appSettings>
   <system.web>

--- a/src/testapps/dotnet6/appsettings.json
+++ b/src/testapps/dotnet6/appsettings.json
@@ -21,7 +21,7 @@
     "RequestValidation": {
       "AuthToken": "MyAuthToken!",
       "AllowLocal": true,
-      "UrlOverride": "https://??????.ngrok.io/sms"
+      "BaseUrlOverride": "https://??????.ngrok.io"
     }
   }
 }


### PR DESCRIPTION
UrlOverride doesn't make sense to configure at the project level, so I changed it to BaseUrlOverride.
The BaseUrlOverride property will override the URL as before, but append the path of the current HTTP request.
This way you can configure the BaseUrlOverride for the whole project without specifying the individual paths of MVC actions. 

This was test for .NET 6, but I need to switch machines to test on Windows.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
