### PR TITLE
Extension methods to convert VoiceResponse and MessagingResponse to TwiMLResult

### DIFF
--- a/src/Twilio.AspNet.Core/MinimalApiTwiMLResult.cs
+++ b/src/Twilio.AspNet.Core/MinimalApiTwiMLResult.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Twilio.TwiML;
 
 // ReSharper disable once CheckNamespace
 namespace Twilio.AspNet.Core.MinimalApi;
@@ -52,5 +53,21 @@ public class TwiMLResult : IResult
         httpContext.Response.ContentType = "application/xml";
         httpContext.Response.ContentLength = Encoding.UTF8.GetByteCount(twiML);
         return httpContext.Response.WriteAsync(twiML);
+    }
+}
+
+// ReSharper disable once InconsistentNaming
+public static class TwiMLExtensions
+{
+    // ReSharper disable once InconsistentNaming
+    public static TwiMLResult ToTwiMLResult(this VoiceResponse voiceResponse)
+    {
+        return new TwiMLResult(voiceResponse);
+    }
+
+    // ReSharper disable once InconsistentNaming
+    public static TwiMLResult ToTwiMLResult(this MessagingResponse messagingResponse)
+    {
+        return new TwiMLResult(messagingResponse);
     }
 }

--- a/src/Twilio.AspNet.Core/TwiMLExtensions.cs
+++ b/src/Twilio.AspNet.Core/TwiMLExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Twilio.TwiML;
+
+namespace Twilio.AspNet.Core
+{
+    // ReSharper disable once InconsistentNaming
+    public static class TwiMLExtensions
+    {
+        // ReSharper disable once InconsistentNaming
+        public static TwiMLResult ToTwiMLResult(this VoiceResponse voiceResponse)
+        {
+            return new TwiMLResult(voiceResponse);
+        }
+
+        // ReSharper disable once InconsistentNaming
+        public static TwiMLResult ToTwiMLResult(this MessagingResponse messagingResponse)
+        {
+            return new TwiMLResult(messagingResponse);
+        }
+    }
+}


### PR DESCRIPTION
Implements #61 

As there are two `TwiMLResult` classes (one for Minimal API and one for controller-based approach) I had to create to classes for the extension methods and put them in the respective namespaces.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
