### PR TITLE
Improve RequestValidationHelper.cs

### DIFF
--- a/src/Twilio.AspNet.Core.UnitTests/RequestValidationHelperTests.cs
+++ b/src/Twilio.AspNet.Core.UnitTests/RequestValidationHelperTests.cs
@@ -49,6 +49,7 @@ public class ContextMocks
         {
             Request.Setup(x => x.Method).Returns("POST");
             Request.Setup(x => x.Form).Returns(form);
+            Request.Setup(x => x.HasFormContentType).Returns(true);
         }
     }
 

--- a/src/Twilio.AspNet.Core/RequestValidationHelper.cs
+++ b/src/Twilio.AspNet.Core/RequestValidationHelper.cs
@@ -47,22 +47,14 @@ namespace Twilio.AspNet.Core
                 ? $"{request.Scheme}://{(request.IsHttps ? request.Host.Host : request.Host.ToUriComponent())}{request.Path}{request.QueryString}"
                 : urlOverride;
 
-            IFormCollection form = null;
-            try
-            {
-                form = request.Form;
-            }
-            catch
-            {
-                // ignore errors accessing invalid/non-existant form
-            }
+            var parameters = request.HasFormContentType ? 
+                request.Form.Keys.ToDictionary(k => k, k => request.Form[k].ToString())
+                : null;
             
             var validator = new RequestValidator(authToken);
             return validator.Validate(
                 url: fullUrl,
-                parameters: form?.Count > 0
-                    ? form.Keys.ToDictionary(k => k, k => form[k].ToString())
-                    : new Dictionary<string, string>(),
+                parameters: parameters,
                 expected: request.Headers["X-Twilio-Signature"]
             );
         }


### PR DESCRIPTION
Exceptions are costly for performance. This PR removes usage of exception handling to detect a form body.

It also passes in `null` instead of a new `Dictionary` when there's no form body.
Alternatively, we could cache a single empty dictionary instead of creating a new one every time.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
