### PR TITLE
Add missing `formattingOptions` parameter to `ToTwiMLResult` extension method

### DIFF
--- a/src/Twilio.AspNet.Core/TwiMLExtensions.cs
+++ b/src/Twilio.AspNet.Core/TwiMLExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Twilio.TwiML;
+﻿using System.Xml.Linq;
+using Twilio.TwiML;
 
 namespace Twilio.AspNet.Core
 {
@@ -11,6 +12,15 @@ namespace Twilio.AspNet.Core
         /// <returns></returns>
         public static TwiMLResult ToTwiMLResult(this VoiceResponse voiceResponse)
             => new TwiMLResult(voiceResponse);
+        
+        /// <summary>
+        /// Returns a properly formatted TwiML response
+        /// </summary>
+        /// <param name="voiceResponse"></param>
+        /// <param name="formattingOptions">Specifies how to format TwiML</param>
+        /// <returns></returns>
+        public static TwiMLResult ToTwiMLResult(this VoiceResponse voiceResponse, SaveOptions formattingOptions)
+            => new TwiMLResult(voiceResponse, formattingOptions);
 
         /// <summary>
         /// Returns a properly formatted TwiML response
@@ -19,5 +29,14 @@ namespace Twilio.AspNet.Core
         /// <returns></returns>
         public static TwiMLResult ToTwiMLResult(this MessagingResponse messagingResponse)
             => new TwiMLResult(messagingResponse);
+
+        /// <summary>
+        /// Returns a properly formatted TwiML response
+        /// </summary>
+        /// <param name="messagingResponse"></param>
+        /// <param name="formattingOptions">Specifies how to format TwiML</param>
+        /// <returns></returns>
+        public static TwiMLResult ToTwiMLResult(this MessagingResponse messagingResponse, SaveOptions formattingOptions)
+            => new TwiMLResult(messagingResponse, formattingOptions);
     }
 }


### PR DESCRIPTION
Add missing `formattingOptions` parameter to `ToTwiMLResult` extension method

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
