### PR TITLE
Use forwarded headers in test app

### DIFF
--- a/src/testapps/AspNetCore/Program.cs
+++ b/src/testapps/AspNetCore/Program.cs
@@ -18,6 +18,8 @@ builder.Services.AddSwaggerGen();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
+app.UseForwardedHeaders();
+
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Home/Error");

--- a/src/testapps/AspNetCore/appsettings.json
+++ b/src/testapps/AspNetCore/appsettings.json
@@ -21,7 +21,7 @@
     "RequestValidation": {
       "AuthToken": "MyAuthToken!",
       "AllowLocal": false,
-      "BaseUrlOverride": "https://90e6b6c4f366.ngrok.io"
+      "BaseUrlOverride": null
     }
   }
 }


### PR DESCRIPTION
Instead of using `BaseUrlOverride`, you can use the forwarded headers middleware to configure the HTTP request with the original HTTP request URL received by the reverse proxy, such as ngrok.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.