### PR TITLE
Change `AllowLocal` default to `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twilio helper library for ASP.NET
+﻿# Twilio helper library for ASP.NET
 
 [![Build](https://github.com/twilio-labs/twilio-aspnet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/twilio-labs/twilio-aspnet/actions/workflows/ci.yml)
 
@@ -293,7 +293,7 @@ Then configure the request validation:
     "AuthToken": "[YOUR_AUTH_TOKEN]",
     "RequestValidation": {
       "AuthToken": "[YOUR_AUTH_TOKEN]",
-      "AllowLocal": true,
+      "AllowLocal": false,
       "BaseUrlOverride": "https://??????.ngrok.io"
     }
   }
@@ -316,7 +316,7 @@ builder.Services
   .AddTwilioRequestValidation((serviceProvider, options) =>
   {
     options.AuthToken = "[YOUR_AUTH_TOKEN]";
-    options.AllowLocal = true;
+    options.AllowLocal = false;
     options.BaseUrlOverride = "https://??????.ngrok.io";
   });
 ```
@@ -430,7 +430,7 @@ In your _Web.config_ you can configure request validation like shown below:
        <requestValidation 
          authToken="[YOUR_AUTH_TOKEN]"
          baseUrlOverride="https://??????.ngrok.io"
-         allowLocal="true"
+         allowLocal="false"
        />
     </twilio>
 </configuration>
@@ -444,7 +444,7 @@ You can also configure request validation using app settings:
     <appSettings>
       <add key="twilio:requestValidation:authToken" value="[YOUR_AUTH_TOKEN]"/>
       <add key="twilio:requestValidation:baseUrlOverride" value="https://??????.ngrok.io"/>
-      <add key="twilio:requestValidation:allowLocal" value="true"/>
+      <add key="twilio:requestValidation:allowLocal" value="false"/>
     </appSettings>
 </configuration>
 ```
@@ -452,7 +452,7 @@ You can also configure request validation using app settings:
 If you configure request validation using both ways, app setting will overwrite the `twilio/requestValidation` configuration element.
 
 A couple of notes about the configuration:
-- `allowLocal` will skip validation when the HTTP request originated from localhost.
+- `allowLocal` will skip validation when the HTTP request originated from localhost. ⚠️ Only use this during development, as this will make your application vulnerable to Server-Side Request Forgery.
 - Use `baseUrlOverride` in case you are in front of a reverse proxy or a tunnel like ngrok. The path of the current request will be appended to the `baseUrlOverride` for request validation.
 
 > **Warning**
@@ -527,7 +527,7 @@ bool IsValidTwilioRequest(HttpContext httpContext)
         urlOverride = $"{options.BaseUrlOverride.TrimEnd('/')}{request.Path}{request.QueryString}";
     }
 
-    return RequestValidationHelper.IsValidRequest(httpContext, options.AuthToken, urlOverride, options.AllowLocal ?? true);
+    return RequestValidationHelper.IsValidRequest(httpContext, options.AuthToken, urlOverride, options.AllowLocal);
 }
 ```
 

--- a/src/Twilio.AspNet.Core/RequestValidationHelper.cs
+++ b/src/Twilio.AspNet.Core/RequestValidationHelper.cs
@@ -17,8 +17,11 @@ namespace Twilio.AspNet.Core
         /// </summary>
         /// <param name="context">HttpContext to use for validation</param>
         /// <param name="authToken">AuthToken for the account used to sign the request</param>
-        /// <param name="allowLocal">Skip validation for local requests</param>
-        public static bool IsValidRequest(HttpContext context, string authToken, bool allowLocal = true)
+        /// <param name="allowLocal">
+        /// Skip validation for local requests. 
+        /// ⚠️ Only use this during development, as this will make your application vulnerable to Server-Side Request Forgery.
+        /// </param>
+        public static bool IsValidRequest(HttpContext context, string authToken, bool allowLocal = false)
             => IsValidRequest(context, authToken, null, allowLocal);
 
         /// <summary>
@@ -28,12 +31,15 @@ namespace Twilio.AspNet.Core
         /// <param name="context">HttpContext to use for validation</param>
         /// <param name="authToken">AuthToken for the account used to sign the request</param>
         /// <param name="urlOverride">The URL to use for validation, if different from Request.Url (sometimes needed if web site is behind a proxy or load-balancer)</param>
-        /// <param name="allowLocal">Skip validation for local requests</param>
+        /// <param name="allowLocal">
+        /// Skip validation for local requests. 
+        /// ⚠️ Only use this during development, as this will make your application vulnerable to Server-Side Request Forgery.
+        /// </param>
         public static bool IsValidRequest(
             HttpContext context, 
             string authToken, 
             string urlOverride, 
-            bool allowLocal = true
+            bool allowLocal = false
         )
         {
             var request = context.Request;

--- a/src/Twilio.AspNet.Core/TwilioOptions.cs
+++ b/src/Twilio.AspNet.Core/TwilioOptions.cs
@@ -22,7 +22,7 @@ namespace Twilio.AspNet.Core
     public class TwilioRequestValidationOptions
     {
         public string AuthToken { get; set; }
-        public bool? AllowLocal { get; set; }
+        public bool AllowLocal { get; set; }
         public string BaseUrlOverride { get; set; }
     }
 

--- a/src/Twilio.AspNet.Core/ValidateRequestAttribute.cs
+++ b/src/Twilio.AspNet.Core/ValidateRequestAttribute.cs
@@ -29,7 +29,7 @@ namespace Twilio.AspNet.Core
             return new InternalValidateRequestAttribute(
                 authToken: options.AuthToken,
                 baseUrlOverride: options.BaseUrlOverride?.TrimEnd('/'),
-                allowLocal: options.AllowLocal ?? true
+                allowLocal: options.AllowLocal
             );
         }
 
@@ -47,7 +47,10 @@ namespace Twilio.AspNet.Core
             /// The Base URL (protocol + hostname) to use for validation,
             /// if different from Request.Url (sometimes needed if web site is behind a proxy or load-balancer)
             /// </param>
-            /// <param name="allowLocal">Skip validation for local requests</param>
+            /// <param name="allowLocal">
+            /// Skip validation for local requests. 
+            /// ⚠️ Only use this during development, as this will make your application vulnerable to Server-Side Request Forgery.
+            /// </param>
             public InternalValidateRequestAttribute(string authToken, string baseUrlOverride, bool allowLocal)
             {
                 AuthToken = authToken;

--- a/src/Twilio.AspNet.Core/ValidateTwilioRequestFilter.cs
+++ b/src/Twilio.AspNet.Core/ValidateTwilioRequestFilter.cs
@@ -25,7 +25,7 @@ public class ValidateTwilioRequestFilter : IEndpointFilter
         
         AuthToken = options.AuthToken;
         BaseUrlOverride = options.BaseUrlOverride?.TrimEnd('/');
-        AllowLocal = options.AllowLocal ?? true;
+        AllowLocal = options.AllowLocal;
     }
 
     public async ValueTask<object> InvokeAsync(

--- a/src/Twilio.AspNet.Core/ValidateTwilioRequestMiddleware.cs
+++ b/src/Twilio.AspNet.Core/ValidateTwilioRequestMiddleware.cs
@@ -34,7 +34,7 @@ namespace Twilio.AspNet.Core
                 urlOverride = $"{options.BaseUrlOverride.TrimEnd('/')}{request.Path}{request.QueryString}";
             }
 
-            var isValid = RequestValidationHelper.IsValidRequest(context, options.AuthToken, urlOverride, options.AllowLocal ?? true);
+            var isValid = RequestValidationHelper.IsValidRequest(context, options.AuthToken, urlOverride, options.AllowLocal);
             if (!isValid)
             {
                 context.Response.StatusCode = (int) HttpStatusCode.Forbidden;

--- a/src/Twilio.AspNet.Mvc/RequestValidationHelper.cs
+++ b/src/Twilio.AspNet.Mvc/RequestValidationHelper.cs
@@ -17,8 +17,11 @@ namespace Twilio.AspNet.Mvc
         /// </summary>
         /// <param name="context">HttpContext to use for validation</param>
         /// <param name="authToken">AuthToken for the account used to sign the request</param>
-        /// <param name="allowLocal">Skip validation for local requests</param>
-        public static bool IsValidRequest(HttpContextBase context, string authToken, bool allowLocal = true)
+        /// <param name="allowLocal">
+        /// Skip validation for local requests. 
+        /// ⚠️ Only use this during development, as this will make your application vulnerable to Server-Side Request Forgery.
+        /// </param>
+        public static bool IsValidRequest(HttpContextBase context, string authToken, bool allowLocal = false)
         {
             return IsValidRequest(context, authToken, null, allowLocal);
         }
@@ -30,8 +33,11 @@ namespace Twilio.AspNet.Mvc
         /// <param name="context">HttpContext to use for validation</param>
         /// <param name="authToken">AuthToken for the account used to sign the request</param>
         /// <param name="urlOverride">The URL to use for validation, if different from Request.Url (sometimes needed if web site is behind a proxy or load-balancer)</param>
-        /// <param name="allowLocal">Skip validation for local requests</param>
-        public static bool IsValidRequest(HttpContextBase context, string authToken, string urlOverride, bool allowLocal = true)
+        /// <param name="allowLocal">
+        /// Skip validation for local requests. 
+        /// ⚠️ Only use this during development, as this will make your application vulnerable to Server-Side Request Forgery.
+        /// </param>
+        public static bool IsValidRequest(HttpContextBase context, string authToken, string urlOverride, bool allowLocal = false)
         {
             if (allowLocal && context.Request.IsLocal && !context.Request.Headers.AllKeys.Contains("X-Forwarded-For"))
             {

--- a/src/Twilio.AspNet.Mvc/ValidateRequestAttribute.cs
+++ b/src/Twilio.AspNet.Mvc/ValidateRequestAttribute.cs
@@ -49,7 +49,7 @@ namespace Twilio.AspNet.Mvc
             AllowLocal = allowLocalAppSetting != null
                 ? bool.Parse(allowLocalAppSetting)
                 : requestValidationConfiguration?.AllowLocal
-                  ?? true;
+                  ?? false;
         }
 
         public override void OnActionExecuting(ActionExecutingContext filterContext)


### PR DESCRIPTION
This PR changes the request validation filters and middleware so that the `AllowLocal` option defaults to `false` instead of `true`.
This is a breaking change and will be released in the next major release.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
