### PR TITLE
Trim trailing slash from BaseUrlOverride

### DIFF
--- a/src/Twilio.AspNet.Core.UnitTests/ValidateTwilioRequestTests.cs
+++ b/src/Twilio.AspNet.Core.UnitTests/ValidateTwilioRequestTests.cs
@@ -27,7 +27,7 @@ public class ValidateTwilioRequestTests
         {
             AuthToken = "My Twilio:RequestValidation:AuthToken",
             AllowLocal = false,
-            BaseUrlOverride = "https://example.localhost"
+            BaseUrlOverride = "https://example.localhost/"
         }
     };
 
@@ -55,7 +55,7 @@ public class ValidateTwilioRequestTests
             });
             c.Request.Headers.Add(
                 "X-Twilio-Signature", ValidationHelper.CalculateSignature(
-                    $"{ValidTwilioOptions.RequestValidation.BaseUrlOverride}{c.Request.Path}",
+                    $"{ValidTwilioOptions.RequestValidation.BaseUrlOverride.TrimEnd('/')}{c.Request.Path}",
                     ValidTwilioOptions.RequestValidation.AuthToken,
                     c.Request.Form
                 )

--- a/src/Twilio.AspNet.Core/RequestValidationHelper.cs
+++ b/src/Twilio.AspNet.Core/RequestValidationHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -34,7 +35,7 @@ namespace Twilio.AspNet.Core
             string urlOverride = null;
             if (!string.IsNullOrEmpty(baseUrlOverride))
             {
-                urlOverride = $"{baseUrlOverride}{request.Path}{request.QueryString}";
+                urlOverride = $"{baseUrlOverride.AsSpan().TrimEnd('/')}{request.Path}{request.QueryString}";
             }
 
             return await IsValidRequestAsync(context, authToken, urlOverride, allowLocal).ConfigureAwait(false);

--- a/src/Twilio.AspNet.Mvc/ValidateRequestAttribute.cs
+++ b/src/Twilio.AspNet.Mvc/ValidateRequestAttribute.cs
@@ -42,15 +42,15 @@ namespace Twilio.AspNet.Mvc
                         ?? requestValidationConfiguration?.AuthToken
                         ?? throw new Exception("Twilio Auth Token not configured");
 
-            BaseUrlOverride = appSettings["twilio:requestValidation:baseUrlOverride"]
-                              ?? requestValidationConfiguration?.BaseUrlOverride;
-            if (BaseUrlOverride != null) BaseUrlOverride = BaseUrlOverride.TrimEnd('/');
+            BaseUrlOverride = (appSettings["twilio:requestValidation:baseUrlOverride"]
+                               ?? requestValidationConfiguration?.BaseUrlOverride)
+                ?.TrimEnd('/');
 
             var allowLocalAppSetting = appSettings["twilio:requestValidation:allowLocal"];
             AllowLocal = allowLocalAppSetting != null
                 ? bool.Parse(allowLocalAppSetting)
                 : requestValidationConfiguration?.AllowLocal
-                ?? false;
+                  ?? false;
         }
 
         public override void OnActionExecuting(ActionExecutingContext filterContext)


### PR DESCRIPTION
Trim trailing slash from `BaseUrlOverride` in Twilio.AspNet.Core

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
