### PR TITLE
Remove test reporter from GHA CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,12 @@ jobs:
     permissions:
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
-          dotnet-quality: ga
+          dotnet-version: 9.x
 
       - name: Update project versions
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,20 +109,12 @@ jobs:
         shell: pwsh
       
       - name: (Twilio.AspNet.Core.UnitTests) Test
-        run: dotnet test --no-build --logger trx
+        run: dotnet test --no-build --no-restore
         working-directory: src/Twilio.AspNet.Core.UnitTests/
         shell: pwsh
 
-      - name: (Twilio.AspNet.Core.UnitTests) Report Tests
-        uses: dorny/test-reporter@v1
-        if: success() || failure() # run this step even if previous step failed
-        with:
-          name: Twilio.AspNet.Core.UnitTests
-          path: src/Twilio.AspNet.Core.UnitTests/TestResults/*.trx
-          reporter: dotnet-trx
-        
       - name: (Twilio.AspNet.Core) Pack
-        run: dotnet pack -c Release -o ..\..\
+        run: dotnet pack --no-build --no-restore -c Release -o ..\..\ 
         working-directory: src/Twilio.AspNet.Core/
         shell: pwsh
 
@@ -156,20 +148,12 @@ jobs:
         shell: pwsh
         
       - name: (Twilio.AspNet.Mvc.UnitTests) Test
-        run: dotnet test --no-build --logger trx
+        run: dotnet test --no-build --no-restore
         working-directory: src/Twilio.AspNet.Mvc.UnitTests/
         shell: pwsh
         
-      - name: (Twilio.AspNet.Mvc.UnitTests) Report Tests
-        uses: dorny/test-reporter@v1
-        if: success() || failure() # run this step even if previous step failed
-        with:
-          name: Twilio.AspNet.Mvc.UnitTests
-          path: src/Twilio.AspNet.Mvc.UnitTests/TestResults/*.trx
-          reporter: dotnet-trx
-        
       - name: (Twilio.AspNet.Mvc) Pack
-        run: dotnet pack -c Release -o ..\..\
+        run: dotnet pack --no-build --no-restore -c Release -o ..\..\
         working-directory: src/Twilio.AspNet.Mvc/
         shell: pwsh
         

--- a/src/Twilio.AspNet.sln
+++ b/src/Twilio.AspNet.sln
@@ -31,6 +31,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Twilio.AspNet.Mvc.UnitTests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Twilio.AspNet.Core.UnitTests", "Twilio.AspNet.Core.UnitTests\Twilio.AspNet.Core.UnitTests.csproj", "{B3E732C9-27EF-4E96-B620-5B5DA57D9AD3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{9B3D65CE-AF46-4122-885D-1CFE42D5EAFB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{4CAACCDD-6731-4617-9DE4-B6495B96DE08}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
+		..\.github\workflows\release.yml = ..\.github\workflows\release.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,5 +71,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7D0F9171-129A-4B05-809E-F501DBC23197}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9B3D65CE-AF46-4122-885D-1CFE42D5EAFB} = {339A75DF-3315-4CF3-9FD9-DAF1B0DB50B2}
+		{4CAACCDD-6731-4617-9DE4-B6495B96DE08} = {9B3D65CE-AF46-4122-885D-1CFE42D5EAFB}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
I don't think the test reporter is worth the hassle.
It only works for PRs made by users with contribution permissions on the repo.
This change removes the test reporter so you just look at the logs instead of a report to figure out what's up with the tests.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
